### PR TITLE
Display timestamps and IDs in !read command output

### DIFF
--- a/lady_luck.js
+++ b/lady_luck.js
@@ -811,14 +811,15 @@ function handle_message(msg) {
                                         channel.messages.fetch({ limit: 100 }).then(messages => {
                                                 const ordered = Array.from(messages.values()).reverse();
                                                 var output = '';
-                                                for (const m of ordered) {
-                                                        const line = `${m.author.username}: ${m.content}`;
-                                                        if (output.length + line.length + 1 > 1900) {
-                                                                msg.channel.send(output);
-                                                                output = '';
-                                                        }
-                                                        output += line + '\n';
-                                                }
+                                               for (const m of ordered) {
+                                                       const timestamp = m.createdAt ? m.createdAt.toISOString() : new Date(m.createdTimestamp).toISOString();
+                                                       const line = `${timestamp} (${m.id}) ${m.author.username}: ${m.content}`;
+                                                       if (output.length + line.length + 1 > 1900) {
+                                                               msg.channel.send(output);
+                                                               output = '';
+                                                       }
+                                                       output += line + '\n';
+                                               }
                                                 if (output.length > 0) {
                                                         msg.channel.send(output);
                                                 }


### PR DESCRIPTION
## Summary
- Include message timestamp and ID when using the `!read` command for easier tracking of messages

------
https://chatgpt.com/codex/tasks/task_e_6896e306827483259386da5d75f2f142