### PR TITLE
Add admin reply command with attachment forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ listed in the `trueAdmins` array inside `auth.json`.
 * `!say <channel_id> <message>` — Sends a message to the given channel ID.
 * `!read <channel_id>` — Reads the last 100 messages from the channel and
   prints them back in chunks.
+* `!reply <message_id> <response>` — Replies to the specified message across any channel, forwarding any attachments from the invoking message.
 
 # Inviting To Your Server
 

--- a/lady_luck.js
+++ b/lady_luck.js
@@ -705,7 +705,7 @@ function wcShow(msg, user_id) {
 	msg.reply(user.toString() + " has " + wc[guild.id].users[user.id].bonus_points + " Bonus Points and is " + wc[guild.id].users[user.id].word_count + " words toward their next one.");
 }
 
-function handle_message(msg) {
+async function handle_message(msg) {
 	const words = msg.content.split(/\s+/);
 	const command = words[0].toLowerCase();
 
@@ -829,6 +829,34 @@ function handle_message(msg) {
                         }
                         if (!located) {
                                 msg.reply('Channel not found.');
+                        }
+                        break;
+                case '!reply':
+                        if (!isTrueAdmin(msg.author.id)) break;
+                        const targetMessageId = words[1];
+                        const replyText = words.slice(2).join(' ');
+                        var responded = false;
+                        const files = Array.from(msg.attachments.values()).map(att => ({ attachment: att.url, name: att.name }));
+                        for (const client of clients) {
+                                if (responded) break;
+                                for (const channel of client.channels.cache.values()) {
+                                        if (responded) break;
+                                        if (channel.type !== 'text' && channel.type !== 'GUILD_TEXT' && channel.type !== 'dm' && channel.type !== 'DM') continue;
+                                        try {
+                                                const target = await channel.messages.fetch(targetMessageId);
+                                                const options = { content: replyText };
+                                                if (files.length > 0) {
+                                                        options.files = files;
+                                                }
+                                                await target.reply(options);
+                                                responded = true;
+                                        } catch (err) {
+                                                // ignore fetch errors
+                                        }
+                                }
+                        }
+                        if (!responded) {
+                                msg.reply('Message not found.');
                         }
                         break;
         }


### PR DESCRIPTION
## Summary
- Allow true admins to reply to any message across all connected clients via `!reply`
- Forward attachments from the invoking message to the target reply
- Document new `!reply` command in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check lady_luck.js`


------
https://chatgpt.com/codex/tasks/task_e_6896e546f9b08325b60c024b94eca031