### PR TITLE
Consolidate reply logic into enhanced say command

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,9 @@ listed in the `trueAdmins` array inside `auth.json`.
 
 * `!guilds` — Lists all guilds the bot is in by name and ID.
 * `!channels <guild_id>` — Lists the channels in the specified guild.
-* `!say <channel_id> <message>` — Sends a message to the given channel ID.
+* `!say <channel_id> <message>` — Sends a message to the given channel ID. Optionally provide a message ID to reply to a specific message: `!say <channel_id> <message_id> <message>`.
 * `!read <channel_id>` — Reads the last 100 messages from the channel and
   prints them back in chunks.
-* `!reply <message_id> <response>` — Replies to the specified message across any channel, forwarding any attachments from the invoking message.
 
 # Inviting To Your Server
 


### PR DESCRIPTION
## Summary
- Allow `!say` to optionally target a message ID and reply with attachments
- Acknowledge success or missing channel/message
- Remove `!reply` command and update documentation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689708a9f84c8325a3b81ba12b29cd2d