### PR TITLE
Include category info in channels command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The bot can be controlled across all servers by Discord users whose IDs are
 listed in the `trueAdmins` array inside `auth.json`.
 
 * `!guilds` — Lists all guilds the bot is in by name and ID.
-* `!channels <guild_id>` — Lists the channels in the specified guild.
+* `!channels <guild_id>` — Lists the channels in the specified guild along with each channel's category and ID, if applicable.
 * `!say <channel_id> <message>` — Sends a message to the given channel ID. Optionally provide a message ID to reply to a specific message: `!say <channel_id> <message_id> <message>`.
 * `!read <channel_id>` — Reads the last 100 messages from the channel and
   prints them back in chunks.

--- a/lady_luck.js
+++ b/lady_luck.js
@@ -773,7 +773,9 @@ async function handle_message(msg) {
                                         guildFound = true;
                                         var channelNames = [];
                                         guild.channels.cache.filter(ch => ch.type === 'text' || ch.type === 'GUILD_TEXT').forEach(ch => {
-                                                channelNames.push(`${ch.name} (${ch.id})`);
+                                                const category = ch.parent;
+                                                const categoryInfo = category ? ` - ${category.name} (${category.id})` : '';
+                                                channelNames.push(`${ch.name} (${ch.id})${categoryInfo}`);
                                         });
                                         sendLongMessage(msg.channel, channelNames.join('\n') || 'No channels.');
                                         break;


### PR DESCRIPTION
## Summary
- Include category name and ID for each channel listed by `!channels`
- Document category details in `!channels` README entry

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b1d9906ac832587cc16ca49e92ecd